### PR TITLE
feat: create design token

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,8 @@
 @import 'tailwindcss';
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #1f2937;
+  --foreground: #f3f3f7;
 }
 
 @theme inline {
@@ -10,13 +10,9 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-}
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+  --color-primary: #02b694;
+  --color-secondary: #a1a8af;
 }
 
 body {
@@ -24,7 +20,6 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
-
 
 .container {
   width: 1600px;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,6 +13,7 @@
 
   --color-primary: #02b694;
   --color-secondary: #a1a8af;
+  --color-sub-background: #2a374a;
 }
 
 body {


### PR DESCRIPTION
## \#️⃣ 관련 이슈

#7) 디자인 토큰 정의

## 💻 주요 변경 사항

- 디자인했을 때 정했던 주요 색깔들 전역 변수화하였습니다.
  - @theme에 저장해서 `bg-primary`, `text-primary`와 같은 유틸리티 클래스가 자동 생성되도록 했습니다! 이 방식이 `:root`를 쓰는 것보다 더 편할 거 같아서 채택했습니다.
- `background`: 배경
- `foreground`: 글자색, 버튼색
- `primary`: 강조색
- `secondary`: hover, disable 등 이벤트색

## 💬 To. 리뷰어

- 더 추가해야할 것들이 있을까요?? 
