### PR TITLE
feat: 설문 페이지 컴포넌트 생성  (/question)

### DIFF
--- a/src/app/question/page.tsx
+++ b/src/app/question/page.tsx
@@ -1,8 +1,8 @@
 export default function QuestionPage() {
   return (
     <div className="container flex h-dvh flex-col items-center justify-between md:justify-start">
-      <main className="w-full md:mb-[5.375rem]">
-        <div className="grid w-full gap-y-10 md:gap-y-[3.125rem]">
+      <main className="w-full md:mb-20">
+        <div className="grid w-full gap-y-10">
           {/* <QuestionContent /> */}
           {/* <RadioGroup /> */}
         </div>

--- a/src/app/question/page.tsx
+++ b/src/app/question/page.tsx
@@ -1,7 +1,7 @@
 export default function QuestionPage() {
   return (
-    <div className="container flex h-dvh flex-col items-center justify-between md:justify-start">
-      <main className="w-full md:mb-20">
+    <div className="container flex min-h-dvh flex-col items-center justify-between md:justify-start">
+      <main className="mb-10 w-full md:mb-20">
         <div className="grid w-full gap-y-10">
           {/* <QuestionContent /> */}
           {/* <RadioGroup /> */}

--- a/src/app/question/page.tsx
+++ b/src/app/question/page.tsx
@@ -1,4 +1,4 @@
-export default function SurveyPage() {
+export default function QuestionPage() {
   return (
     <div className="container flex h-dvh flex-col items-center justify-between md:justify-start">
       <main className="w-full md:mb-[5.375rem]">

--- a/src/app/question/page.tsx
+++ b/src/app/question/page.tsx
@@ -1,0 +1,15 @@
+export default function SurveyPage() {
+  return (
+    <div className="container flex h-dvh flex-col items-center justify-between md:justify-start">
+      <main className="w-full md:mb-[5.375rem]">
+        <div className="grid w-full gap-y-10 md:gap-y-[3.125rem]">
+          {/* <QuestionContent /> */}
+          {/* <RadioGroup /> */}
+        </div>
+      </main>
+      <nav className="mb-10 w-full md:mb-0 md:w-[30.5rem]">
+        {/* <ProgressBar /> */}
+      </nav>
+    </div>
+  );
+}


### PR DESCRIPTION
## \#️⃣ 관련 이슈

- #12 

## 💻 주요 변경 사항

- 설문 페이지 컴포넌트를 생성했습니다
- 주요 컴포넌트 (`<QuestionContent />`, `<RadioGroup />`, `<ProgressBar />`) 사이 여백을 설정했습니다.

|iphone SE|iphone 14 pro max|Desktop|
|:---:|:---:|:---:|
|![se](https://github.com/user-attachments/assets/8360d205-25f8-4d1f-a934-20c3e779f0ad)|![14](https://github.com/user-attachments/assets/066eee78-f679-40f8-9e42-b0a6d6eef202)|![dt](https://github.com/user-attachments/assets/090313ff-f375-483a-9c6e-3895d15c916b)|

> 구조 이해를 위해 스크린샷 찍을 때만 임의로 추가한 컨텐츠입니다. 실제로 실행해보면 아무 것도 없는 게 맞아용

  - 피그마 수치와 동일하게 구현하되, rem으로 변환했을 때 소수점 두 자리 이상인 경우에 대해서는 임의 조정했습니다.
    
    ![image](https://github.com/user-attachments/assets/0426ae78-dc06-491d-8944-a3e9110cec65)


## 💬 To. 리뷰어

