### PR TITLE
feat: 시작 페이지 레이아웃 설정

### DIFF
--- a/src/app/start/page.tsx
+++ b/src/app/start/page.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+export default function StartPage() {
+  const router = useRouter();
+
+  const handleStart = () => {
+    const input = document.getElementById('nickname-input') as HTMLInputElement;
+    const nickname = input?.value.trim();
+
+    if (!nickname.trim()) {
+      alert('닉네임을 입력해 주세요.');
+      return;
+    }
+
+    localStorage.setItem('nickname', nickname);
+    router.push('/question');
+  };
+
+  return (
+    <div className="container flex h-dvh flex-col items-center">
+      <main className="flex h-[calc(100%-11rem)] w-full max-w-md flex-col justify-between space-y-10 py-6 text-center">
+        <div className="mt-10 text-3xl leading-[4rem] font-bold">
+          <p>
+            <span className="text-primary">개발자 </span>
+            유형테스트
+          </p>
+          <p className="mt-2 text-xl">나는 어떤 개발자일까?</p>
+        </div>
+        <div className="space-y-6">
+          <input
+            id="nickname-input"
+            type="text"
+            placeholder="닉네임을 입력해 주세요."
+            className="focus:ring-primary w-full border-b border-gray-400 bg-transparent px-4 py-2 text-center placeholder-gray-400 focus:ring-2 focus:outline-none"
+          />
+          <button
+            onClick={handleStart}
+            className="rounded-full bg-white px-8 py-3 font-semibold text-black transition hover:bg-gray-200"
+          >
+            Start
+          </button>
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## \#️⃣ 관련 이슈

- #14 

## 💻 주요 변경 사항

- 시작 페이지 레이아웃
- 닉네임 LocalStorage에 저장
- Start 버튼 클릭 시 설문 페이지로 이동

## 💬 To. 리뷰어

- 우선 따로 `/start/page.tsx`를 만들긴 했는데 추후에 기본 홈으로 변경할까 싶습니다!
- 닉네임은 결과페이지에서 출력해야 하니 LocalStorage에 저장하는 방식을 사용했는데 더 좋은 방법이 있을까요?? 🤔 따로 라이브러리를 사용하기엔 규모가 크지 않아 그럴 필요는 없어보여 일단 이렇게 처리했습니다..
