### PR TITLE
feat: 설문 페이지 질문 간 화면 전환 로직 구현

### DIFF
--- a/src/app/question/hooks/useQuestionProgress.ts
+++ b/src/app/question/hooks/useQuestionProgress.ts
@@ -1,0 +1,60 @@
+import { useReducer } from 'react';
+import { Action, State } from '@/app/question/types/questionProgress';
+import QUESTIONS from '@/app/question/data/questions.json';
+
+const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case 'SELECT_ANSWER':
+      return {
+        ...state,
+        answers: {
+          ...state.answers,
+          [action.payload.questionId]: action.payload.selected,
+        },
+      };
+    case 'PREV_QUESTION':
+      return {
+        ...state,
+        currentIndex: state.currentIndex - 1,
+      };
+    case 'NEXT_QUESTION':
+      return {
+        ...state,
+        currentIndex: state.currentIndex + 1,
+      };
+    default:
+      return state;
+  }
+};
+
+export const useQuestionProgress = () => {
+  const [state, dispatch] = useReducer(reducer, {
+    currentIndex: 0,
+    answers: {},
+  });
+
+  const prev = () => {
+    if (state.currentIndex == 0) return;
+    dispatch({ type: 'PREV_QUESTION' });
+  };
+
+  const next = () => {
+    if (state.currentIndex == QUESTIONS.length - 1) return;
+    dispatch({ type: 'NEXT_QUESTION' });
+  };
+
+  const select = (questionId: number, selected: number) => {
+    dispatch({
+      type: 'SELECT_ANSWER',
+      payload: { questionId, selected },
+    });
+  };
+
+  return {
+    currentIndex: state.currentIndex,
+    answers: state.answers,
+    prev,
+    next,
+    select,
+  };
+};

--- a/src/app/question/page.tsx
+++ b/src/app/question/page.tsx
@@ -1,14 +1,44 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import { useQuestionProgress } from './hooks/useQuestionProgress';
+import QUESTIONS from '@/app/question/data/questions.json';
+import QuestionContent from './components/QuestionContent';
+import RadioGroup from './components/RadioGroup';
+import ProgressBar from './components/ProgressBar';
+
 export default function QuestionPage() {
+  const { currentIndex, answers, prev, next, select } = useQuestionProgress();
+  const question = QUESTIONS[currentIndex];
+
+  const router = useRouter();
+
+  const handleChange = (selected: number) => {
+    const isFirstAnswer = !answers[question.id];
+    select(question.id, selected);
+
+    const isLastQuestion = currentIndex === QUESTIONS.length - 1;
+    if (isLastQuestion) {
+      router.push('/result');
+    } else if (isFirstAnswer) {
+      setTimeout(next, 300);
+    }
+  };
+
   return (
     <div className="container flex min-h-dvh flex-col items-center justify-between md:justify-start">
       <main className="mb-10 w-full md:mb-20">
         <div className="grid w-full gap-y-10">
-          {/* <QuestionContent /> */}
-          {/* <RadioGroup /> */}
+          <QuestionContent text={question.question} id={question.id} />
+          <RadioGroup onChange={handleChange} active={answers[question.id]} />
         </div>
       </main>
       <nav className="mb-10 w-full md:mb-0 md:w-[30.5rem]">
-        {/* <ProgressBar /> */}
+        <ProgressBar
+          currentIndex={currentIndex}
+          hasAnswer={!!answers[question.id]}
+          clickPrev={prev}
+          clickNext={next}
+        />
       </nav>
     </div>
   );

--- a/src/app/question/types/questionProgress.ts
+++ b/src/app/question/types/questionProgress.ts
@@ -1,0 +1,18 @@
+export interface State {
+  currentIndex: number;
+  answers: Record<number, number>;
+}
+
+interface SelectAction {
+  type: 'SELECT_ANSWER';
+  payload: {
+    questionId: number;
+    selected: number;
+  };
+}
+
+interface MoveAction {
+  type: 'PREV_QUESTION' | 'NEXT_QUESTION';
+}
+
+export type Action = SelectAction | MoveAction;


### PR DESCRIPTION
## \#️⃣ 관련 이슈

- #17 

## 💻 주요 변경 사항

<!-- 이번 PR에서 작업한 내용을 설명해주세요. -->

- 질문 진행 상태를 관리하는 커스텀 훅 `useQuestionProgress` 를 만들었습니다.

- 설문 페이지 컴포넌트에 커스텀 훅 / 하위 컴포넌트를 적용했습니다.

  |모바일|데스크톱|
  |---|---|
  | ![question](https://github.com/user-attachments/assets/9e81af7b-1d0b-495a-b4a2-4dbdd1a97736) | ![image](https://github.com/user-attachments/assets/e618a76f-9a39-4891-8b64-f25ca2028ae7) |

## 💬 To. 리뷰어

<!-- 진행하며 들었던 의문이나 의논하고 싶은 부분, 리뷰어가 중점적으로 확인하길 원하는 부분이 있다면 작성해주세요. -->
<!-- 예: 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

내용이 조금 긴데 😿 확인 후 항목별로 의견 남겨주시면 좋을 거 같아요

###  `<QuestionContent />` 스타일 수정 제안

현재는 질문 길이에 따라 높이가 달라져서, 긴 문장이 등장할 경우 덜컹이는 느낌이 있습니다.
➡️ **질문 확정 후 가장 긴 질문 기준으로 `<p>` 태그의 높이를 고정하는 건 어떨까요**

이렇게 하면 질문 간 전환 시 전체 레이아웃이 흔들리지 않아 보기에 더 깔끔할 거 같아요

### 레이아웃 수정 제안 (데스크톱)

배율 100% 기준으로 세로 스크롤이 생기고 있는데, 상하단 여백이나 콘텐츠 간 여백으로 발생하는 불필요한 스크롤로 보여요
**➡️수치 조정해서 스크롤 없이 한 화면 내에 모든 요소가 들어올 수 있게 조정하면 어떨까요**

--- 

두 제안 모두 진행하게 될 경우 별도 이슈로 분리할 예정입니다


