### PR TITLE
feat: 질문 문장에 줄바꿈 추가 및 자연스러운 표현으로 수정

### DIFF
--- a/src/app/question/data/questions.json
+++ b/src/app/question/data/questions.json
@@ -1,200 +1,92 @@
 [
   {
     "id": 1,
-    "question": "계획 단계보다 결과물을 빠르게 보고 피드백을 받는다.",
+    "question": "계획보다 결과물을 빠르게\n만들고 피드백을 받는 편이다.",
     "weights": ["야생형"],
     "inverseWeights": ["교과서형"]
   },
   {
     "id": 2,
-    "question": "공식 문서보다 직접 실행해보는 것을 우선시한다.",
-    "weights": ["야생형"],
-    "inverseWeights": ["교과서형"]
-  },
-  {
-    "id": 3,
-    "question": "작은 실험 코드로 동작을 확인하며 주요 로직을 만들어 간다.",
-    "weights": ["야생형"],
+    "question": "GPT 없이 개발하는 것은\n이제 상상하기도 어렵다.",
+    "weights": ["지피티형"],
     "inverseWeights": []
   },
   {
+    "id": 3,
+    "question": "개발 역량은 알고리즘 실력으로\n평가된다고 생각한다.",
+    "weights": ["문제집형"],
+    "inverseWeights": ["야생형", "교과서형"]
+  },
+  {
     "id": 4,
-    "question": "새로운 기능을 구현할 때, 완벽한 계획 없이 즉시 코드를 작성한다.",
-    "weights": ["야생형"],
-    "inverseWeights": ["교과서형"]
+    "question": "개발 전에 이론과 개념을\n꼼꼼히 익혀야 안심된다.",
+    "weights": ["교과서형"],
+    "inverseWeights": ["야생형"]
   },
   {
     "id": 5,
-    "question": "계획보다는 직접 부딪히며 배우는 것이 내 스타일이다.",
+    "question": "새로운 기술은 프로젝트로\n배우는 게 가장 효과적이다.",
     "weights": ["야생형"],
     "inverseWeights": ["교과서형"]
   },
   {
     "id": 6,
-    "question": "모든 문법을 외우지 않고 그때그때 찾아서 쓰는 편이다",
-    "weights": ["야생형"],
-    "inverseWeights": []
+    "question": "다른 사람이 짠 코드를 보면\n화가 날 때가 있다.",
+    "weights": ["교과서형"],
+    "inverseWeights": ["지피티형"]
   },
   {
     "id": 7,
-    "question": "개발을 잘 한다는 것은 코드를 빠르게 짜는 것이다.",
-    "weights": ["야생형"],
-    "inverseWeights": ["교과서형"]
+    "question": "GPT 서버가 다운돼서\n개발을 중단한 적이 있다.",
+    "weights": ["지피티형"],
+    "inverseWeights": []
   },
   {
     "id": 8,
-    "question": "새로운 기술을 접하면, 일단 프로젝트를 만들면서 배우는 것이 효과적이라고 생각한다.",
+    "question": "새로운 기술 도입을 먼저\n제안하거나 직접 사용해 본다.",
+    "weights": ["메뚜기형"],
+    "inverseWeights": []
+  },
+  {
+    "id": 9,
+    "question": "프로젝트보다는\n코딩테스트로 배우는 편이다.",
+    "weights": ["문제집형"],
+    "inverseWeights": ["야생형", "교과서형"]
+  },
+  {
+    "id": 10,
+    "question": "계획보다는 직접 부딪히며\n배우는 것이 내 스타일이다.",
     "weights": ["야생형"],
     "inverseWeights": ["교과서형"]
   },
   {
-    "id": 9,
-    "question": "직접 부딪히며 배우는 것보다 계획하는 것이 내 스타일이다.",
-    "weights": ["교과서형"],
-    "inverseWeights": ["야생형"]
-  },
-  {
-    "id": 10,
-    "question": "문서에 나온 순서대로 학습 계획을 세워 진행한다.",
-    "weights": ["교과서형"],
-    "inverseWeights": ["야생형"]
-  },
-  {
     "id": 11,
-    "question": "공식 튜토리얼과 학습 자료를 최대한 활용한다.",
-    "weights": ["교과서형"],
-    "inverseWeights": ["야생형"]
+    "question": "복잡한 로직 구현 전\nGPT와 설계 방향을 조율한다.",
+    "weights": ["지피티형"],
+    "inverseWeights": []
   },
   {
     "id": 12,
-    "question": "개념을 완전히 숙지한 뒤에야 본격적인 구현에 들어간다.",
-    "weights": ["교과서형"],
-    "inverseWeights": ["야생형"]
+    "question": "문제 해결 시 정답보다\n다양한 해결법을 먼저 고려한다.",
+    "weights": ["메뚜기형"],
+    "inverseWeights": []
   },
   {
     "id": 13,
-    "question": "전체 목차를 이해한 후 단계별로 예제를 따라 실습한다.",
+    "question": "전체 목차를 살펴본 뒤, 단계별\n예제를 따라 실습하는 편이다.",
     "weights": ["교과서형"],
     "inverseWeights": ["야생형"]
   },
   {
     "id": 14,
-    "question": "개발을 시작하기 전에 이론과 개념을 꼼꼼히 공부해야 마음이 놓인다.",
-    "weights": ["교과서형"],
-    "inverseWeights": ["야생형"]
+    "question": "주변 개발자들보다 다양한\n개발 분야를 시도해 본 편이다.",
+    "weights": ["메뚜기형"],
+    "inverseWeights": []
   },
   {
     "id": 15,
-    "question": "다른 사람이 짠 코드를 보면 화가 날 때가 있다.",
-    "weights": ["교과서형"],
-    "inverseWeights": ["지피티형"]
-  },
-  {
-    "id": 16,
-    "question": "버그가 발생했을 때 혼자 힘으로 디버깅을 잘하는 편이다.",
-    "weights": ["교과서형"],
-    "inverseWeights": ["지피티형"]
-  },
-  {
-    "id": 17,
-    "question": "복잡한 로직 구현 전, GPT와 대화하며 설계 방향을 조율한다.",
-    "weights": ["지피티형"],
-    "inverseWeights": []
-  },
-  {
-    "id": 18,
-    "question": "주석이나 설명이 필요할 때 AI에게 자동 생성해 달라 요청한다.",
-    "weights": ["지피티형"],
-    "inverseWeights": []
-  },
-  {
-    "id": 19,
-    "question": "GPT 서버가 다운돼서 개발을 중단한 적이 있다",
-    "weights": ["지피티형"],
-    "inverseWeights": []
-  },
-  {
-    "id": 20,
-    "question": "GPT없이 개발하는 것은 이제 상상하기도 어렵다.",
-    "weights": ["지피티형"],
-    "inverseWeights": []
-  },
-  {
-    "id": 21,
-    "question": "AI가 해주는 코드 리뷰가 사람이 해주는 리뷰보다 낫다고 생각한다.",
-    "weights": ["지피티형"],
-    "inverseWeights": []
-  },
-  {
-    "id": 22,
-    "question": "알고리즘 대회를 참여하거나 모의 테스트를 정기적으로 수행한다.",
-    "weights": ["문제집형"],
-    "inverseWeights": []
-  },
-  {
-    "id": 23,
-    "question": "문제를 풀 때마다 시간 기록을 남겨 효율성을 관리한다.",
-    "weights": ["문제집형"],
-    "inverseWeights": []
-  },
-  {
-    "id": 24,
-    "question": "문제 해결 전략(투포인터, DFS 등)을 유형별로 정리해둔다.",
-    "weights": ["문제집형"],
-    "inverseWeights": []
-  },
-  {
-    "id": 25,
-    "question": "특정 수준의 난이도(예: BOJ Gold 이상) 문제를 목표로 설정한다.",
-    "weights": ["문제집형"],
-    "inverseWeights": []
-  },
-  {
-    "id": 26,
-    "question": "실제 서비스를 만드는 것보다 알고리즘 문제를 푸는 시간이 더 많다.",
+    "question": "서비스 개발보다 알고리즘 공부에\n더 많은 시간을 쓴다.",
     "weights": ["문제집형"],
     "inverseWeights": ["야생형", "교과서형"]
-  },
-  {
-    "id": 27,
-    "question": "코딩테스트와 알고리즘 해결 역량만이 개발자의 역량을 판단한다고 생각한다.",
-    "weights": ["문제집형"],
-    "inverseWeights": ["야생형", "교과서형"]
-  },
-  {
-    "id": 28,
-    "question": "프로젝트보다는 코딩테스트로 배우는 편이다.",
-    "weights": ["문제집형"],
-    "inverseWeights": ["야생형", "교과서형"]
-  },
-  {
-    "id": 29,
-    "question": "여러 프로젝트를 동시에 진행하며 언어 전환이 잦다.",
-    "weights": ["메뚜기형"],
-    "inverseWeights": []
-  },
-  {
-    "id": 30,
-    "question": "깊은 이해보다는 작동 원리 파악에 만족하는 편이다.",
-    "weights": ["메뚜기형", "야생형"],
-    "inverseWeights": ["교과서형"]
-  },
-  {
-    "id": 31,
-    "question": "주변 개발자들을 봤을 때, 나는 다양한 개발 분야도 시도해본 편이다.",
-    "weights": ["메뚜기형"],
-    "inverseWeights": []
-  },
-  {
-    "id": 32,
-    "question": "새로운 기술이 나오면 가장 먼저 도입해보자고 이야기하거나 시도해본다.",
-    "weights": ["메뚜기형"],
-    "inverseWeights": []
-  },
-  {
-    "id": 33,
-    "question": "문제를 해결할 때 완벽한 정답을 찾는 것 이전에, 다양한 기술로 해결하는 방법을 생각해본다.",
-    "weights": ["메뚜기형"],
-    "inverseWeights": []
   }
 ]


### PR DESCRIPTION
## \#️⃣ 관련 이슈

<!-- #(이슈번호)를 통해 이슈를 연결해주세요. -->

- #27 

## 💻 주요 변경 사항

<!-- 이번 PR에서 작업한 내용을 설명해주세요. -->

- `question` 필드에 `\n`을 추가했습니다.

- 일부 질문이 수정되었습니다.

  - 모든 질문이 SE 기준 2줄 내로 표시되게 수정했습니다.
  - 맞춤법이 틀리거나 문장 부호가 빠진 경우를 수정했습니다. ([부산대 맞춤법 검사기](https://nara-speller.co.kr/speller) 돌렸어요)
  - 문장이 어색한 경우를 수정했습니다.

![question](https://github.com/user-attachments/assets/cc114b5d-b378-49ee-bf90-85cbbbce540a)

## 💬 To. 리뷰어

<!-- 진행하며 들었던 의문이나 의논하고 싶은 부분, 리뷰어가 중점적으로 확인하길 원하는 부분이 있다면 작성해주세요. -->
<!-- 예: 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

어제 회의에서 알려주신 `word-break:keep-all` 을 사용하지 않은 이유는 다음과 같습니다.

- 텍스트가 2줄 이상일 때, 줄바꿈 위치에 따라 시각적 비중이 맞지 않는 경우가 있습니다 (첫 줄에 비해 둘째 줄이 너무 짧거나)

  - `text-wrap:balance` 추가 적용을 고려했으나 `봤을 때` `만드는 것` 같은 경우에 어색한 줄바꿈이 일어나는 경우가 있습니다  

    | 예시 1 | 예시 2 |
    |---|---|
    |![c1](https://github.com/user-attachments/assets/506cc0eb-f8f3-4491-b247-aa10a8fd7b24)|![c2](https://github.com/user-attachments/assets/a77daf11-797c-459d-b794-aa9e0586a9b0)|

  - `word-break`와 `text-balance`를 적용하되 위 사진처럼 어색하게 줄바꿈이 생기는 질문에만 `\n`을 추가할 수도 있겠지만,
    관리 상의 일관성이 떨어진다고 생각했습니다 (다른 팀원이 코드만 보고는 의도를 파악하기 어려울 거 같았어요)

따라서 모든 질문이 2줄 안에 표시되도록 내용을 수정하고, 일괄적으로 `\n`을 삽입했습니다.

