### PR TITLE
style: 설문 페이지 레이아웃 수정

### DIFF
--- a/src/app/question/components/QuestionContent.tsx
+++ b/src/app/question/components/QuestionContent.tsx
@@ -6,7 +6,7 @@ interface QuestionContentProps {
 export default function QuestionContent({ id, text }: QuestionContentProps) {
   return (
     <div className="w-full">
-      <p className="mb-3.75 text-3xl font-bold text-white md:mb-10 md:text-5xl">{`Q${id}.`}</p>
+      <p className="text-3xl font-bold text-white md:text-5xl">{`Q${id}.`}</p>
       <p className="text-2xl font-semibold whitespace-pre-line text-white md:text-4xl">
         {text}
       </p>

--- a/src/app/question/page.tsx
+++ b/src/app/question/page.tsx
@@ -26,8 +26,8 @@ export default function QuestionPage() {
 
   return (
     <div className="container flex min-h-dvh flex-col items-center justify-between md:justify-start">
-      <main className="mb-10 w-full md:mb-20">
-        <div className="grid w-full gap-y-10">
+      <main className="mb-10 w-full md:mb-10">
+        <div className="grid w-full gap-y-8">
           <QuestionContent text={question.question} id={question.id} />
           <RadioGroup onChange={handleChange} active={answers[question.id]} />
         </div>


### PR DESCRIPTION
## \#️⃣ 관련 이슈

<!-- #(이슈번호)를 통해 이슈를 연결해주세요. -->

- #40

## 💻 주요 변경 사항

<!-- 이번 PR에서 작업한 내용을 설명해주세요. -->

-  데스크톱 100% 기준으로 세로 스크롤이 생기고 있었는데, 컴포넌트 사이 여백을 조절해 없앴습니다

| | 전 | 후 |
|---|---|---|
|데스크톱|![image](https://github.com/user-attachments/assets/e2cd8538-461b-40d2-94cf-8767768f19f8)|![image](https://github.com/user-attachments/assets/78a5a053-b0ae-4b39-8441-58ef0db4cfdd)|
|SE|![image](https://github.com/user-attachments/assets/037addac-ec21-41e0-95d4-7b88b1f4e735)|![image](https://github.com/user-attachments/assets/84e32f7b-ed80-4cb5-8797-6f4e9b98ba91)|
|14 pro|![image](https://github.com/user-attachments/assets/cf39e4ad-503b-446c-8a4e-a55f3a5aff71)|![image](https://github.com/user-attachments/assets/4e38ed1a-d528-4c9e-9c78-f7500d96785b)|

## 💬 To. 리뷰어

<!-- 진행하며 들었던 의문이나 의논하고 싶은 부분, 리뷰어가 중점적으로 확인하길 원하는 부분이 있다면 작성해주세요. -->
<!-- 예: 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- `<QuestionContent />`의 마진을 아예 삭제했는데, `global.css`에서 걸어둔 `line-height`로 텍스트 사이 세로 여백은 충분하다고 생각해서 지웠어요