### PR TITLE
feat: save test result to localStorage

### DIFF
--- a/src/app/question/page.tsx
+++ b/src/app/question/page.tsx
@@ -5,6 +5,7 @@ import QUESTIONS from '@/app/question/data/questions.json';
 import QuestionContent from './components/QuestionContent';
 import RadioGroup from './components/RadioGroup';
 import ProgressBar from './components/ProgressBar';
+import { calculateResult } from "./utils/calculateResult";
 
 export default function QuestionPage() {
   const { currentIndex, answers, prev, next, select } = useQuestionProgress();
@@ -18,6 +19,8 @@ export default function QuestionPage() {
 
     const isLastQuestion = currentIndex === QUESTIONS.length - 1;
     if (isLastQuestion) {
+      const testResult = calculateResult(QUESTIONS, answers);
+      localStorage.setItem('typeResult', JSON.stringify(testResult));
       router.push('/result');
     } else if (isFirstAnswer) {
       setTimeout(next, 300);


### PR DESCRIPTION
## \#️⃣ 관련 이슈
- #42 

## 💻 주요 변경 사항

(선행 PR(#36)이 완료되면 정상 작동하는 코드입니다!)

- calculateResult의 결과를 localStorage에 `typeResult`로 저장합니다.

## 💬 To. 리뷰어
- 늦어서 죄송합니다! result 페이지로 넘어가기 전에 동기로 진행하는 코드입니다.
- 결과 페이지의 test 코드를 기반으로 작성하였습니다.